### PR TITLE
Update groups/groups.class.php

### DIFF
--- a/groups/groups.class.php
+++ b/groups/groups.class.php
@@ -26,7 +26,7 @@ class BPSP_Groups {
      * Constructor. Loads filters and actions.
      */
     function BPSP_Groups() {
-        add_action( 'bp_groups_setup_nav', array( &$this, 'set_nav' ) );
+        add_action( 'bp_init', array( &$this, 'set_nav' ) );
         add_filter( 'groups_get_groups', array( &$this, 'extend_search' ), 10, 2 );
         add_action( 'groups_admin_tabs', array( &$this, 'group_admin_tab' ), 10, 2 );
         add_action( 'wp', array( &$this, 'group_admin_screen' ), 4 );


### PR DESCRIPTION
bp_groups_setup_nav action is part of the default theme I suspect as it's not present on my install of 1.6.4 and we don't use the default theme.
changing it to bp_init did the trick, so I'm offering it up as a change. Without it, it would just 404.

Thanks!
